### PR TITLE
Add sending close frame on close

### DIFF
--- a/src/whisky.nim
+++ b/src/whisky.nim
@@ -215,6 +215,12 @@ proc newWebSocket*(url: string): WebSocket =
 proc close*(ws: WebSocket, timeout = -1) {.raises: [].} =
   try:
     ws.send("", Close)
-    ws.socket.close()
+    var frame: Frame
+    try:
+      frame = ws.receiveFrame(timeout)
+    except:
+      discard
   except:
     discard
+  finally:
+    ws.socket.close()


### PR DESCRIPTION
When using Whisky with Mummy, just closing the socket causes Mummy to fire off an ErrorEvent in the server side. From what I can see it notices that it hasn't sent a Close frame before the socket was severed by the client. If I grok the websocket protocol correctly (glanced at the other async ws library for Nim) the client side should send a Close frame and ideally wait for the corresponding answering Close frame before closing the socket. This change made the ErrorEvent in Mummy server side go away :) 