### PR TITLE
Expose WebSocket socket field

### DIFF
--- a/src/whisky.nim
+++ b/src/whisky.nim
@@ -5,7 +5,7 @@ export options
 
 type
   WebSocket* = ref object
-    socket: Socket
+    socket*: Socket
 
   Frame = object
     fin: bool


### PR DESCRIPTION
## Summary
- Make the `socket` field on `WebSocket` public so users can set socket options like `TCP_NODELAY` on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)